### PR TITLE
method getEmails missed required param inboxId

### DIFF
--- a/index.js
+++ b/index.js
@@ -228,7 +228,7 @@ class MailSlurp {
    * @returns {Promise<[Email]>} emails.
    */
   async grabAllEmailsFromMailbox() {
-    const emailPreviews = await this.mailslurp.getEmails();
+    const emailPreviews = await this.mailslurp.getEmails(this.currentMailbox.id);
     output.debug(`Received ${emailPreviews.length} emails`);
     return Promise.all(emailPreviews.map(e => this.mailslurp.getEmail(e.id)));
   }


### PR DESCRIPTION
According to mailslurp-client [Doc](https://github.com/mailslurp/mailslurp-client/blob/c5d4ad11e8cb79ea0aa24c9ae159a0751d8060d4/docs/classes/_index_.mailslurp.md#getemails) getEmails has required param inboxId
I added this.
tested locally. 