### PR TITLE
Improve resillience when any CodeceptJS helper crashes in "_before"

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class MailSlurp {
   }
 
   async _after() {
-    if (!this.mailboxes.length) return;
+    if (!this.mailboxes || !this.mailboxes.length) return;
     await Promise.all(this.mailboxes.map(m => this.mailslurp.deleteInbox(m.id)));
     output.debug(`Removed ${this.mailboxes.length} mailboxes`);
     this.mailboxes = [];


### PR DESCRIPTION
If something breaks in "_before" in any helper, then "mailslurper" helper will throw an unnecessary error, because "this.mailboxes" is "undefined":
🔴 "Cannot read property 'length' of undefined"

This PR fixes it.