### PR TITLE
added: new steps "I.seeEmailAttachment" and "I.seeNumberOfEmailAttachments"

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ assert.eql(email.subject, 'Thanks for registering')
         -   [Parameters](#parameters-12)
     -   [dontSeeEmailSubjectEquals](#dontseeemailsubjectequals)
         -   [Parameters](#parameters-13)
+    -   [seeNumberOfEmailAttachments](#seenumberofemailattachments)
+        -   [Parameters](#parameters-14)
+    -   [seeEmailAttachment](#seeemailattachment)
+        -   [Parameters](#parameters-15)
 
 ### MailSlurp
 
@@ -357,4 +361,35 @@ Requires an opened email. Use either `waitForEmail*` methods to open. Or open ma
 
 ##### Parameters
 
--   `text`  
+-   `text`
+
+#### seeNumberOfEmailAttachments
+
+Checks that current email has expected number of attachments.
+
+```js
+I.seeNumberOfEmailAttachments(2);
+```
+
+Requires an opened email. Use either `waitForEmail*` methods to open. Or open manually with `I.openEmail()` method.
+
+##### Parameters
+
+-   `number`
+
+#### seeEmailAttachment
+
+Checks that current email has an attachment with specified name.
+
+```js
+I.seeEmailAttachment('ExampleAttachment.pdf');
+```
+
+Be aware that Mailslurp SDK removes special characters in name of attachment,
+e.g. "Example-Attachment.pdf" will have name "ExampleAttachment.pdf".
+
+Requires an opened email. Use either `waitForEmail*` methods to open. Or open manually with `I.openEmail()` method.
+
+##### Parameters
+
+-   `name`  

--- a/index.js
+++ b/index.js
@@ -339,6 +339,53 @@ class MailSlurp {
 
   }
 
+  /**
+   * Checks that current email has expected number of attachments.
+   *
+   * ```js
+   * I.seeNumberOfEmailAttachments(2);
+   * ```
+   *
+   * Requires an opened email. Use either `waitForEmail*` methods to open. Or open manually with `I.openEmail()` method.
+   */
+  seeNumberOfEmailAttachments(number) {
+    this._hasCurrentEmail();
+    const email = this.currentEmail;
+    expect(email.attachments.length).to.eql(number, `number of email attachments to equal ${number}`)
+  }
+
+  /**
+   * Checks that current email has an attachment with specified name.
+   *
+   * ```js
+   * I.seeEmailAttachment('ExampleAttachment.pdf');
+   * ```
+   * Be aware that Mailslurp SDK removes special characters in name of attachment,
+   * e.g. "Example-Attachment.pdf" will have name "ExampleAttachment.pdf".
+   *
+   * Requires an opened email. Use either `waitForEmail*` methods to open. Or open manually with `I.openEmail()` method.
+   */
+  async seeEmailAttachment(nameRegExp) {
+    this._hasCurrentEmail();
+    const email = this.currentEmail;
+    let foundAttachmentNames = []
+    for (let attachmentId of email.attachments) {
+      let attachmentMetaData = await this.mailslurp.getAttachmentMetaData(attachmentId, email.id)
+      if (attachmentMetaData.name.match(new RegExp(nameRegExp))) {
+        // Attachment found. We are finished here.
+        return
+      }
+      foundAttachmentNames.push(attachmentMetaData.name)
+    }
+    expect.fail(
+        `Attachment with name "${nameRegExp}" not found in e-mail with subject "${email.subject}".`
+        + (foundAttachmentNames.length > 0 ?
+            ` Found attachments: "${foundAttachmentNames.join(',')}"`
+            : ' No attachments found at all in e-mail.'
+        )
+    )
+  }
+
   _hasCurrentEmail() {
     if (!this.currentEmail) throw new Error('No email opened. Open an email with waitForEmail* methods');
   }

--- a/mailslurp_test.js
+++ b/mailslurp_test.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const { expect } = require('chai');
 const MailSlurp = require('./index');
+const fs = require('fs')
 
 let I;
 
@@ -24,11 +25,22 @@ describe('MailSlurp helper', function () {
   });
 
   it('should send and receive an email', async () => {
+    const attachmentFilename = 'README.md';
+    // Mailslurp automatically modifies filename and adds dynamic characters. Therefore we need RegExp here.
+    const attachmentRegexp = 'README.*\.md';
+
     const mailbox = await I.haveNewMailbox();
+    const fileBase64Encoded = await fs.promises.readFile(attachmentFilename, { encoding: 'base64' });
+    const [ attachmentId ] = await I.mailslurp.uploadAttachment({
+      base64Contents: fileBase64Encoded,
+      contentType: 'text/plain',
+      filename: attachmentFilename,
+    });
     await I.sendEmail({
       to: [mailbox.emailAddress],
       subject: 'Hello Test',
-      body: 'Testing'       
+      body: 'Testing',
+      attachments: [ attachmentId ]
     });
     const email = await I.waitForLatestEmail(50);
     expect(email.body.trim()).to.eql('Testing');
@@ -38,6 +50,8 @@ describe('MailSlurp helper', function () {
     await I.seeInEmailBody('Testing');
     await I.dontSeeInEmailBody('Email');
     await I.dontSeeInEmailSubject('Bye');
+    await I.seeNumberOfEmailAttachments(1);
+    await I.seeEmailAttachment(attachmentRegexp);
   });
 
 


### PR DESCRIPTION
This PR introduces two new steps to enable the test engineer to easily test for existence of email attachments.

I.seeNumberOfEmailAttachments(1)

I.seeEmailAttachment('example.pdf')