### PR TITLE
feature: new step "I.haveExistingMailbox(mailboxId)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ assert.eql(email.subject, 'Thanks for registering')
 -   [Configuration](#configuration)
     -   [Parameters](#parameters)
     -   [haveNewMailbox](#havenewmailbox)
+    -   [haveExistingMailbox](#haveexistingmailbox)
     -   [openMailbox](#openmailbox)
         -   [Parameters](#parameters-1)
     -   [sendEmail](#sendemail)
@@ -136,6 +137,14 @@ Switches to last created mailbox.
 
 ```js
 const mailbox = await I.haveNewMailbox();
+```
+
+#### haveExistingMailbox
+
+Use existing mailbox.
+
+```js
+const mailbox = await I.haveExistingMailbox('94cxxxf4-7231-46ce-9f40-xxxcae39xxxx');
 ```
 
 #### openMailbox

--- a/index.js
+++ b/index.js
@@ -79,6 +79,27 @@ class MailSlurp {
   }
 
   /**
+   * Use an existing mailbox.
+   *
+   * ```js
+   * const mailbox = await I.haveExistingMailbox('94cxxxf4-7231-46ce-9f40-xxxcae39xxxx');
+   * ```
+   * @param {string} mailboxId ID of an existing MailSlurp inbox.
+   * @returns {Promise<Inbox>}
+   */
+  async haveExistingMailbox(mailboxId) {
+    if (!mailboxId) {
+      throw new Error('Id of existing mailbox must be provided in parameters.')
+    }
+
+    const inbox = await this.mailslurp.getInbox(mailboxId)
+    inbox.toString = () => inbox.emailAddress;
+    this.mailboxes.push(inbox);
+    this.currentMailbox = inbox;
+    return inbox;
+  }
+
+  /**
   * Change a current mailbox to a provided one:
   * 
   * ```js


### PR DESCRIPTION
…to use an existing mailslurp inbox for testing.


Motivation: Why testing with permanent / existing mailboxes?
This is helpful in scenarios where Mailslurp users created permanent inbox.
Permanent inboxes have the advantage over dynamic inboxes that you can use them in scenarios where you configured redirect rules in other inboxes that then send mails to permanent mailslurp inboxes.